### PR TITLE
Lagt til støtte for navngitte sqlparametre

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.pam.stilling.feed
 
+import no.nav.pam.stilling.feed.config.PSTMTUtil
 import no.nav.pam.stilling.feed.config.TxContext
 import no.nav.pam.stilling.feed.config.TxTemplate
 import no.nav.pam.stilling.feed.dto.Feed
@@ -7,6 +8,7 @@ import no.nav.pam.stilling.feed.dto.FeedItem
 import no.nav.pam.stilling.feed.dto.FeedPageItem
 import no.nav.pam.stilling.feed.dto.KonsumentDTO
 import org.slf4j.LoggerFactory
+import java.sql.PreparedStatement
 import java.sql.Timestamp
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -114,27 +116,25 @@ class FeedRepository(private val txTemplate: TxTemplate) {
         return txTemplate.doInTransaction(txContext) { ctx ->
             val feedPageItems = mutableListOf<FeedPageItem>()
             // NB: Dette garanterer ikke at vi har monotont stigende sist_endret...
-            val sistEndretClause = if (sistEndret == null) ""
-                else
-                    " and sist_endret >= ? "
-            val sistEndretIdx = if (sistEndret == null) 0 else 1
+            var sistEndretClause = ""
+            val params = mutableMapOf<String, (pstmt: PreparedStatement, pos: Int) -> Unit>(
+                Pair(":seq_no:") { pstmt, pos -> pstmt.setObject(pos, seqNo) },
+                Pair(":antall:") { pstmt, pos -> pstmt.setInt(pos, antall) }
+            )
+            sistEndret?.let { s ->
+                sistEndretClause = " and sist_endret >= :sist_endret: "
+                params[":sist_endret:"] = { pstmt, pos -> pstmt.setTimestamp(pos, Timestamp(s.toInstant().toEpochMilli())) }
+            }
 
             val sql = """
                 select id, sist_endret, seq_no, status, title, business_name, municipal, feed_item_id
                 from feed_page_item
-                where seq_no > ? $sistEndretClause
+                where seq_no > :seq_no: $sistEndretClause
                 order by seq_no
-                limit ?
+                limit :antall:
             """.trimIndent()
             val c = ctx.connection()
-            c.prepareStatement(sql).apply {
-                this.setObject(1, seqNo)
-                sistEndret?.let { s ->
-                    this.setTimestamp(2, Timestamp(s.toInstant().toEpochMilli()))
-                }
-
-                this.setInt(2+sistEndretIdx, antall)
-            }.use { statement ->
+            PSTMTUtil.prepareStatement(c, sql, params).use { statement ->
                 val resultSet = statement.executeQuery()
                 while (resultSet.next())
                     feedPageItems.add(FeedPageItem.fraDatabase(resultSet))

--- a/src/main/kotlin/no/nav/pam/stilling/feed/config/TxTemplate.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/config/TxTemplate.kt
@@ -2,6 +2,7 @@ package no.nav.pam.stilling.feed.config
 
 import org.slf4j.LoggerFactory
 import java.sql.Connection
+import java.sql.PreparedStatement
 import javax.sql.DataSource
 
 /**
@@ -38,7 +39,7 @@ import javax.sql.DataSource
  *   Spring TransactionTemplate er supergenerisk og er i stand til å joine transaksjoner fra andre datakilder (f.eks køer)
  * - Både Spring og TxTemplate baserer seg på at du må utføre det som skal gjøres i en transaksjon innenfor en
  *   doInTransaction() blokk.
- * - Spring tilbyr annotasjoner og aspekter for å abstrehere bort doInTransaction - TxTemplate vil aldri gjøre det
+ * - Spring tilbyr annotasjoner og aspekter for å abstrahere bort doInTransaction - TxTemplate vil aldri gjøre det
  * - Spring lagrer transaction context i en ThreadLocal slik at du ikke trenger å propagere context selv
  *   TxTemplate gjør det eksplisitt. Det gir mer "støy" i koden, men er utrolig mye mer robust,
  *
@@ -92,4 +93,67 @@ class TxContext(private val conn: Connection) {
 
     fun isRollbackOnly() = rollbackOnly
     fun connection() = conn
+}
+
+
+/**
+ * Utilityobjekt som er ment som en fattig trøst for de som savner Spring NamedParameterJdbcTemplate.
+ * Dette er svært enkelt uten noen forsøk på smart eller magisk logikk. Det er basert på enkel substituering
+ * av :verdi: til ? i en streng, og en måte å holde orden på hvilken ordinal verdien skal ha.
+ *
+ * Forventet bruk/oppførsel:
+ *
+ * ```
+ * val params = mapOf<String, (pstmt: PreparedStatement, pos: Int) -> Unit>(
+ *     Pair(":bar:") { pstmt, pos -> pstmt.setString(pos, "bar_verdi") },
+ *     Pair(":baz:") { pstmt, pos -> pstmt.setString(pos, "baz_verdi") }
+ *   )
+ * val preparedStatement = prepareStatement(connection,
+ *      "select * from foo where bar=:bar: and baz=:baz: and gazonk > :bar:",
+ *      params
+ *    )
+ * preparedStatement.execute()...
+ * ```
+ *
+ * her er forventet oppførsel at prapareStatement returnerer et PreparedStatement med følgende SQL:
+ * ```
+ * "select * from foo where bar=? and baz=? and gazonk > ?"
+ * ```
+ * og at følgende kode har kjørt:
+ * ```
+ * pstmt.setString(1, "bar_verdi")
+ * pstmt.setString(2, "baz_verdi")
+ * pstmt.setString(3, "bar_verdi")
+ * ```
+ */
+object PSTMTUtil {
+    fun prepareStatement(conn: Connection, sql: String, params: Map<String, (pstmt: PreparedStatement, pos: Int) -> Unit>) : PreparedStatement {
+        val preparedSql = sql.replace(Regex(":[^:]+:"), "?")
+        val pstmt = conn.prepareStatement(preparedSql)
+
+        val placeholders = findPlaceholders(sql)
+        applyParams(params, placeholders, pstmt)
+
+        return pstmt
+    }
+
+    private fun applyParams(
+        params: Map<String, (pstmt: PreparedStatement, pos: Int) -> Unit>,
+        placeholders: List<String>,
+        pstmt: PreparedStatement
+    ) {
+        params.forEach { me ->
+            var pos = 0
+            placeholders.forEach { p ->
+                pos++
+                if (p == me.key)
+                    me.value(pstmt, pos)
+            }
+        }
+    }
+
+    private fun findPlaceholders(sql: String): List<String> =
+        Regex(":[^:]+:").findAll(sql).map {mr ->
+            mr.value
+        }.toList()
 }

--- a/src/test/kotlin/no/nav/pam/stilling/feed/PSTMTUtilTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/PSTMTUtilTest.kt
@@ -1,0 +1,32 @@
+package no.nav.pam.stilling.feed
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.pam.stilling.feed.config.PSTMTUtil
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.PreparedStatement
+import kotlin.test.assertEquals
+
+
+class PSTMTUtilTest {
+
+    @Test
+    fun skalSubstituereVerdier() {
+        val sql = "select foo from bar where foobar =:foobaz: and gazonk = :foobaz: and id = :id:"
+        val conn = mockk<Connection>()
+        every { conn.prepareStatement(any()) }.returns(mockk<PreparedStatement>())
+        val verdier = Array<String>(3) { p -> "" }
+
+        val params = mapOf<String, (pstmt: PreparedStatement, pos: Int) -> Unit>(
+            Pair(":foobaz:") { pstmt, pos -> verdier[pos-1] = "foo $pos" },
+            Pair(":id:") { pstmt, pos -> verdier[pos-1] = "id $pos" }
+        )
+        val preparedStatement = PSTMTUtil.prepareStatement(conn, sql, params)
+
+        //verdier.forEach { println(it) }
+        assertEquals("foo 1", verdier[0])
+        assertEquals("foo 2", verdier[1])
+        assertEquals("id 3", verdier[2])
+    }
+}


### PR DESCRIPTION
Legger til støtte for noe som ligner springs NamedJdbcTemplate - bare uten alle forsøk på å være cunning

Strengt tatt så er dette muligens kanskje ikke strengt tatt nødvendig, men jeg synes ikke det nødvendige skal legge begrensninger på oss. Et støttebibliotek er tross alt ikke komplett uten minst ett regulært uttrykk, og den ene spørringen som tar det i bruk blir faktisk bedre og lettere å forstå. Så det så.


