### PR TITLE
Legger til kilde og filterer ut FINN-annonser

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/KafkaStillingDetaljerListener.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/KafkaStillingDetaljerListener.kt
@@ -88,6 +88,7 @@ class KafkaStillingDetaljerListener(
         LOG.info("KafkaStillingDetaljerListener - Mottar ${records.count()} records med stillingsannonser: {}", adIds.joinToString(", "))
 
         val ads = records.mapNotNull { it.value() }.map { objectMapper.readValue<AdDTO>(it) }
-        feedService.lagreOppdaterteDetaljer(ads)
+        // feedService.lagreOppdaterteDetaljer(ads) TODO: Legg tilbake denne og fjern lagreKilde når gjennomkjøring er ferdig
+        feedService.lagreKilde(ads)
     }
 }

--- a/src/main/kotlin/no/nav/pam/stilling/feed/dto/DbDTO.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/dto/DbDTO.kt
@@ -9,7 +9,8 @@ data class FeedItem(
     val uuid: UUID,
     val json: String,
     val sistEndret: ZonedDateTime,
-    val status: String
+    val status: String,
+    val kilde: String?
 ) {
     companion object {
         fun fraDatabase(rs: ResultSet, prefix: String = "") = FeedItem(
@@ -17,6 +18,7 @@ data class FeedItem(
             json = rs.getString("${prefix}json"),
             sistEndret = rs.getTimestamp("${prefix}sist_endret").toInstant().atZone(ZoneId.of("Europe/Oslo")),
             status = rs.getString("${prefix}status"),
+            kilde = rs.getString("${prefix}kilde")
         )
     }
 }

--- a/src/main/resources/db/migration/V3__legg_til_kilde.sql
+++ b/src/main/resources/db/migration/V3__legg_til_kilde.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feed_page_item ADD kilde TEXT;
+ALTER TABLE feed_item ADD kilde TEXT;

--- a/src/test/kotlin/no/nav/pam/stilling/feed/OppdaterDetaljerTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/OppdaterDetaljerTest.kt
@@ -2,16 +2,15 @@ package no.nav.pam.stilling.feed
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.pam.stilling.feed.config.TxTemplate
-import no.nav.pam.stilling.feed.dto.AdDTO
-import no.nav.pam.stilling.feed.dto.ContactDTO
-import no.nav.pam.stilling.feed.dto.FeedAd
-import no.nav.pam.stilling.feed.dto.FeedContact
+import no.nav.pam.stilling.feed.dto.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OppdaterDetaljerTest {
@@ -33,12 +32,33 @@ class OppdaterDetaljerTest {
         val ad = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString(), contactList = mutableListOf())
         feedService.lagreNyStillingsAnnonse(ad)
 
-        val hentetAdFørEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid))!!.json)
+        val hentetAdFørEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!.json)
         feedService.lagreOppdaterteDetaljer(listOf(ad.copy(contactList = mutableListOf(ContactDTO(id=null, name="Petter")))))
-        val hentetAdEtterEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid))!!.json)
+        val hentetAdEtterEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!.json)
 
         assertEquals(emptyList(), hentetAdFørEndring.contactList)
         assertEquals(listOf(FeedContact(name="Petter", null, null, null, null)), hentetAdEtterEndring.contactList)
         assertThat(hentetAdFørEndring).usingRecursiveComparison().ignoringFields("contactList").isEqualTo(hentetAdEtterEndring)
+    }
+
+    @Test
+    fun `Oppdater kilde migrering oppdaterer kilde men ikke detaljer`() {
+        val ad = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString(), contactList = mutableListOf(), source = null)
+        feedService.lagreNyStillingsAnnonse(ad)
+
+        val hentetAdFørEndring = feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!
+        feedService.lagreKilde(listOf(ad.copy(contactList = mutableListOf(ContactDTO(id=null, name="Petter")), source = "Stillingsregistrering")))
+        val hentetAdEtterEndring = feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!
+
+        val førEndringJson = objectMapper.readValue<FeedAd>(hentetAdFørEndring.json)
+        val etterEndringJson = objectMapper.readValue<FeedAd>(hentetAdEtterEndring.json)
+
+        assertEquals(emptyList(), førEndringJson.contactList)
+        assertEquals(emptyList(), etterEndringJson.contactList)
+        assertNull(hentetAdFørEndring.kilde)
+        assertNotNull(hentetAdEtterEndring.kilde)
+        assertEquals("Stillingsregistrering", hentetAdEtterEndring.kilde)
+        assertThat(hentetAdFørEndring).usingRecursiveComparison().ignoringFields("kilde").isEqualTo(hentetAdEtterEndring)
+        assertThat(førEndringJson).usingRecursiveComparison().isEqualTo(etterEndringJson)
     }
 }

--- a/src/test/kotlin/no/nav/pam/stilling/feed/servicetest/FeedServiceTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/servicetest/FeedServiceTest.kt
@@ -7,23 +7,27 @@ import no.nav.pam.stilling.feed.dto.Feed
 import no.nav.pam.stilling.feed.dto.FeedAd
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FeedServiceTest {
-    var feedRepository: FeedRepository? = null
-    var feedService: FeedService? = null
-    var txTemplate: TxTemplate? = null
+    lateinit var feedRepository: FeedRepository
+    lateinit var feedService: FeedService
+    lateinit var txTemplate: TxTemplate
 
     @BeforeAll
     fun init() {
         val ds = dataSource
         kjørFlywayMigreringer(ds)
         txTemplate = TxTemplate(ds)
-        feedRepository = FeedRepository(txTemplate!!)
-        feedService = FeedService(feedRepository!!, txTemplate!!, objectMapper)
+        feedRepository = FeedRepository(txTemplate)
+        feedService = FeedService(feedRepository, txTemplate, objectMapper)
     }
 
     private fun antallAnnonser(): Int = dataSource.connection.use {
@@ -51,21 +55,21 @@ class FeedServiceTest {
 
         val antallEksisterendeAnnonser = antallAnnonser()
 
-        feedService!!.lagreNyStillingsAnnonse(ad1)
-        feedService!!.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2))
-        feedService!!.lagreNyStillingsAnnonse(ad1_update)
-        feedService!!.lagreNyStillingsAnnonse(ad3maskert)
+        feedService.lagreNyStillingsAnnonse(ad1)
+        feedService.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2))
+        feedService.lagreNyStillingsAnnonse(ad1_update)
+        feedService.lagreNyStillingsAnnonse(ad3maskert)
 
         val antallAnnonser = antallAnnonser()
         Assertions.assertThat(antallAnnonser - antallEksisterendeAnnonser).isEqualTo(3)
 
-        val lagretAd1 = feedService!!.hentStillingsAnnonse(UUID.fromString(ad1.uuid))!!
+        val lagretAd1 = feedService.hentStillingsAnnonse(UUID.fromString(ad1.uuid))!!
         val lagretFeedAd = objectMapper.readValue(lagretAd1.json, FeedAd::class.java)
         Assertions.assertThat(lagretFeedAd.title).isEqualTo(ad1_update.title)
 
-        val lagretAd3maskert = feedService!!.hentStillingsAnnonse(UUID.fromString(ad3maskert.uuid))!!
+        val lagretAd3maskert = feedService.hentStillingsAnnonse(UUID.fromString(ad3maskert.uuid))!!
         Assertions.assertThat(lagretAd3maskert.json).isEmpty()
-        val feedSide = feedService!!.hentSisteSide()!!
+        val feedSide = feedService.hentSisteSide()!!
         Assertions.assertThat(feedSide.title).isNotEqualTo(ad3maskert.title)
     }
 
@@ -76,16 +80,16 @@ class FeedServiceTest {
             val ad = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java)
                 .copy(uuid = UUID.randomUUID().toString(), title = "Annonse #$i")
             adIds.add(ad.uuid)
-            feedService!!.lagreNyStillingsAnnonse(ad)
+            feedService.lagreNyStillingsAnnonse(ad)
         }
 
         Assertions.assertThat(adIds.size).isEqualTo(Feed.defaultPageSize * 3 + 1)
 
-        var førsteSide = feedService!!.hentFørsteSide()
-        var side = feedService!!.hentFeedHvis(førsteSide!!.id)!!
+        var førsteSide = feedService.hentFørsteSide()
+        var side = feedService.hentFeedHvis(førsteSide!!.id)!!
         side.items.forEach { adIds.remove(it.feed_entry.uuid) }
         while (side.next_id != null) {
-            side = feedService!!.hentFeedHvis(side.next_id!!)!!
+            side = feedService.hentFeedHvis(side.next_id!!)!!
             side.items.forEach { adIds.remove(it.feed_entry.uuid) }
         }
         Assertions.assertThat(adIds).isEmpty()
@@ -100,23 +104,51 @@ class FeedServiceTest {
         val ad3 = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java)
             .copy(uuid = UUID.randomUUID().toString())
 
-        txTemplate!!.doInTransaction { ctx ->
-            feedService!!.lagreNyStillingsAnnonse(ad1, ctx)
+        txTemplate.doInTransaction { ctx ->
+            feedService.lagreNyStillingsAnnonse(ad1, ctx)
 
-            txTemplate!!.doInTransaction { ctxNew -> // Implisitt ny kontekst som ikke er del av eksisterende transaksjon
-                feedService!!.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2), ctxNew)
+            txTemplate.doInTransaction { ctxNew -> // Implisitt ny kontekst som ikke er del av eksisterende transaksjon
+                feedService.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2), ctxNew)
             }
-            txTemplate!!.doInTransaction(ctx) { ctxNew -> // Propagerer kontekst og deltar dermed i eksisterende transaksjon
-                feedService!!.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2), ctxNew)
+            txTemplate.doInTransaction(ctx) { ctxNew -> // Propagerer kontekst og deltar dermed i eksisterende transaksjon
+                feedService.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(ad2), ctxNew)
             }
             ctx.setRollbackOnly()
         }
 
-        val lagretAd1 = feedService!!.hentStillingsAnnonse(UUID.fromString(ad1.uuid))
-        val lagretAd2 = feedService!!.hentStillingsAnnonse(UUID.fromString(ad2.uuid))
-        val lagretAd3 = feedService!!.hentStillingsAnnonse(UUID.fromString(ad3.uuid))
+        val lagretAd1 = feedService.hentStillingsAnnonse(UUID.fromString(ad1.uuid))
+        val lagretAd2 = feedService.hentStillingsAnnonse(UUID.fromString(ad2.uuid))
+        val lagretAd3 = feedService.hentStillingsAnnonse(UUID.fromString(ad3.uuid))
         Assertions.assertThat(lagretAd1?.status).isNull()
         Assertions.assertThat(lagretAd2?.status).isNotNull
         Assertions.assertThat(lagretAd3?.status).isNull()
+    }
+
+    @Test
+    fun `Svarer ikke ut FINN-annonser`() {
+        val ikkeFinnAd1 = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString())
+        val finnAd1 = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString(), source = "FINN")
+        val ikkeFinnAd2 = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString())
+
+        val antallEksisterendeAnnonser = antallAnnonser()
+        val antallEksisterendeFeedItems = feedService.hentFeedHvis(feedService.hentFørsteSide()!!.id, antall = antallEksisterendeAnnonser * 10)!!.items.size
+
+        feedService.lagreNyStillingsAnnonse(ikkeFinnAd1)
+        feedService.lagreNyStillingsAnnonseFraJson(objectMapper.writeValueAsString(finnAd1))
+        feedService.lagreNyStillingsAnnonse(ikkeFinnAd2)
+
+        val antallAnnonser = antallAnnonser()
+        assertEquals(3, antallAnnonser - antallEksisterendeAnnonser)
+
+        val lagretIkkeFinnAd1 = feedService.hentStillingsAnnonse(UUID.fromString(ikkeFinnAd1.uuid))
+        val lagretFinnAd1 = feedService.hentStillingsAnnonse(UUID.fromString(finnAd1.uuid))
+        val lagretIkkeFinnAd2 = feedService.hentStillingsAnnonse(UUID.fromString(ikkeFinnAd2.uuid))
+
+        assertNotNull(lagretIkkeFinnAd1)
+        assertNull(lagretFinnAd1)
+        assertNotNull(lagretIkkeFinnAd2)
+
+        val feedPage = feedService.hentFeedHvis(feedService.hentFørsteSide()!!.id, antall = antallEksisterendeFeedItems + Feed.defaultPageSize)!!
+        assertEquals(2, feedPage.items.size - antallEksisterendeFeedItems)
     }
 }


### PR DESCRIPTION
Trenger å lagre Kilde på `feed_item` og `feed_page_item` for å kunne filtrere ut FINN-stillinger fra API-responsen. 

Highjacker "oppdater detaljer"-listeneren for å legge på kilde på alle eksisterende annonser. Listeneren blir ikke startet i denne PRen, men opplegget er her. 