### PR TITLE
Ignorer direktemeldte stillinger

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/Application.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/Application.kt
@@ -70,8 +70,6 @@ fun startApp(
     val naisController = NaisController(healthService, prometheusRegistry)
     val kafkaListener = KafkaStillingListener(kafkaConsumer, feedService, healthService)
 
-    feedService.fjernDIRFraFeed()
-
     val javalin = startJavalin(
         port = 8080,
         jsonMapper = JavalinJackson(objectMapper),

--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
@@ -85,25 +85,6 @@ class FeedRepository(private val txTemplate: TxTemplate) {
         }
     }
 
-    fun hentDirekteMeldteFeedItem(txContext: TxContext? = null): MutableList<FeedItem>? {
-        return txTemplate.doInTransaction(txContext) { ctx ->
-            val sql = """
-                select id, json, sist_endret, status, kilde
-                from feed_item
-                where kilde='DIR' and status='ACTIVE' 
-            """.trimIndent()
-            val c = ctx.connection()
-            c.prepareStatement(sql).apply {
-            }.use { statement ->
-                val resultSet = statement.executeQuery()
-                val items = mutableListOf<FeedItem>()
-                while (resultSet.next())
-                    items.add(FeedItem.fraDatabase(resultSet))
-                return@doInTransaction items
-            }
-        }
-    }
-
     fun lagreFeedPageItem(feedPage: FeedPageItem, kilde: String?, txContext: TxContext? = null): FeedPageItem {
         return txTemplate.doInTransaction(txContext) { ctx ->
             val sql = """


### PR DESCRIPTION
Fjerner koden som ble brukt til å rydde opp i direktemeldte stillinger.
Ignorerer direktemeldte stillinger slik at de hverken havner i db eller feed.