### PR TITLE
Økt størrelsen på antall database-tilkoblinger som appen kan ha

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/config/DatabaseConfig.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/config/DatabaseConfig.kt
@@ -16,7 +16,7 @@ class DatabaseConfig(env: Map<String, String>,
     fun lagDatasource() = HikariConfig().apply {
         jdbcUrl = "jdbc:postgresql://$host:$port/$database"
         minimumIdle = 1
-        maximumPoolSize = 2
+        maximumPoolSize = 5
         driverClassName = "org.postgresql.Driver"
         initializationFailTimeout = 5000
         username = user


### PR DESCRIPTION
Ser at vi i prod har probelmer med å ha tilgjengelige database-tilkoblinger, og forsøker å løse opp i dette ved å øke dene verdien. Default-verdien til Hikari er 10, setter den nå til halvarten av dette siden vi har to pods.