### PR TITLE
Fiks: oppdater feed-detaljer ved endringer fra StillingsAdmin/NKS

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
@@ -47,23 +47,6 @@ class FeedRepository(private val txTemplate: TxTemplate) {
                 }.executeUpdate()
         } ?: 0
 
-    fun oppdaterKildeForFeedItem(id: UUID, kilde: String) = txTemplate.doInTransaction { ctx ->
-        val connection = ctx.connection()
-        var updated = 0
-
-        updated += connection.prepareStatement("UPDATE feed_item SET kilde = ? WHERE id = ?").apply {
-            this.setString(1, kilde)
-            this.setObject(2, id)
-        }.executeUpdate()
-
-        updated += connection.prepareStatement("UPDATE feed_page_item SET kilde = ? WHERE feed_item_id = ?").apply {
-            this.setString(1, kilde)
-            this.setObject(2, id)
-        }.executeUpdate()
-
-        return@doInTransaction updated
-    } ?: 0
-
     fun hentFeedItem(id: UUID, skalIgnorereFinn: Boolean): FeedItem? {
         return txTemplate.doInTransactionNullable { ctx ->
             val ignorerFinnClause = if (skalIgnorereFinn) " and kilde != 'FINN'" else ""

--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
@@ -112,18 +112,10 @@ class FeedService(
 
         return@map txTemplate.doInTransaction { ctx ->
             val feedAd = mapAd(annonse, stillingUrlBase)
-            val active = annonse.status == "ACTIVE"
+            val active = annonse.status == "ACTIVE" && annonse.source != "DIR" &&
+                    annonse.privacy == "SHOW_ALL"
             val feedJson = if (active) objectMapper.writeValueAsString(feedAd) else ""
             feedRepository.oppdaterFeedItemJson(UUID.fromString(annonse.uuid), feedJson)
-        }
-    }.filterNotNull().sum()
-
-    // TODO Fjern denne etter gjennomkjøring, kun midlertidig for å migrere
-    fun lagreKilde(annonser: List<AdDTO>, txContext: TxContext? = null) = annonser.map { ad ->
-        val kilde = ad.source ?: return@map null
-
-        return@map txTemplate.doInTransaction { ctx ->
-            feedRepository.oppdaterKildeForFeedItem(UUID.fromString(ad.uuid), kilde)
         }
     }.filterNotNull().sum()
 

--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
@@ -46,19 +46,17 @@ class FeedService(
             return null
         }
 
-        return txTemplate.doInTransaction { ctx ->
-            val feedAd = mapAd(ad, stillingUrlBase)
-            val active = ad.status == "ACTIVE" && ad.source != "DIR" &&
-                    ad.privacy == "SHOW_ALL"
+        return txTemplate.doInTransaction { _ ->
+            val active = isActive(ad)
             val statusDescription = if (active) "ACTIVE" else "INACTIVE"
-            val feedJson = if (active) objectMapper.writeValueAsString(feedAd) else ""
+            val feedJson = if (active) objectMapper.writeValueAsString(mapAd(ad, stillingUrlBase)) else ""
 
             val feedItem = FeedItem(
                 uuid = UUID.fromString(ad.uuid),
                 json = feedJson,
                 sistEndret = ad.updated.atZone(ZoneId.of("Europe/Oslo")),
                 status = statusDescription,
-                kilde = feedAd.source
+                kilde = ad.source
             )
             feedRepository.lagreFeedItem(feedItem)
 
@@ -71,7 +69,7 @@ class FeedService(
                 feedItemId = feedItem.uuid,
                 seqNo = -1
             )
-            val lagretPageItem = feedRepository.lagreFeedPageItem(feedPageItem, feedAd.source)
+            val lagretPageItem = feedRepository.lagreFeedPageItem(feedPageItem, ad.source)
 
             return@doInTransaction Pair(feedItem, lagretPageItem)
         }
@@ -110,14 +108,15 @@ class FeedService(
             if (!adSkalMaskeres(ad)) ad
             else ad.copy(title = "...", contactList = mutableListOf(), employer = null, businessName = "")
 
-        return@map txTemplate.doInTransaction { ctx ->
-            val feedAd = mapAd(annonse, stillingUrlBase)
-            val active = annonse.status == "ACTIVE" && annonse.source != "DIR" &&
-                    annonse.privacy == "SHOW_ALL"
-            val feedJson = if (active) objectMapper.writeValueAsString(feedAd) else ""
+        return@map txTemplate.doInTransaction { _ ->
+            val active = isActive(annonse)
+            val feedJson = if (active) objectMapper.writeValueAsString(mapAd(annonse, stillingUrlBase)) else ""
             feedRepository.oppdaterFeedItemJson(UUID.fromString(annonse.uuid), feedJson)
         }
-    }.filterNotNull().sum()
+    }.sum()
+
+    private fun isActive(annonse: AdDTO): Boolean = annonse.status == "ACTIVE" && annonse.source != "DIR" &&
+            annonse.privacy == "SHOW_ALL"
 
     fun lagreNyeStillingsAnnonser(ads: List<AdDTO>, txContext: TxContext? = null): List<Pair<FeedItem, FeedPageItem>> {
         return txTemplate.doInTransaction { ctx ->

--- a/src/main/kotlin/no/nav/pam/stilling/feed/KafkaStillingDetaljerListener.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/KafkaStillingDetaljerListener.kt
@@ -88,7 +88,6 @@ class KafkaStillingDetaljerListener(
         LOG.info("KafkaStillingDetaljerListener - Mottar ${records.count()} records med stillingsannonser: {}", adIds.joinToString(", "))
 
         val ads = records.mapNotNull { it.value() }.map { objectMapper.readValue<AdDTO>(it) }
-        // feedService.lagreOppdaterteDetaljer(ads) TODO: Legg tilbake denne og fjern lagreKilde når gjennomkjøring er ferdig
-        feedService.lagreKilde(ads)
+        feedService.lagreOppdaterteDetaljer(ads)
     }
 }

--- a/src/test/kotlin/no/nav/pam/stilling/feed/OppdaterDetaljerTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/OppdaterDetaljerTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -42,23 +41,34 @@ class OppdaterDetaljerTest {
     }
 
     @Test
-    fun `Oppdater kilde migrering oppdaterer kilde men ikke detaljer`() {
-        val ad = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java).copy(uuid = UUID.randomUUID().toString(), contactList = mutableListOf(), source = null)
+    fun `OppdaterDetaljer oppdaterer orgnr`() {
+        val baseAd = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java)
+        val ad = baseAd
+            .copy(
+                uuid = UUID.randomUUID().toString(),
+                employer = baseAd.employer?.copy(orgnr = null)
+            )
         feedService.lagreNyStillingsAnnonse(ad)
 
-        val hentetAdFørEndring = feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!
-        feedService.lagreKilde(listOf(ad.copy(contactList = mutableListOf(ContactDTO(id=null, name="Petter")), source = "Stillingsregistrering")))
-        val hentetAdEtterEndring = feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!
+        val hentetAdFørEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!.json)
+        feedService.lagreOppdaterteDetaljer(listOf(ad.copy(employer = ad.employer?.copy(orgnr = "922422249"))))
+        val hentetAdEtterEndring = objectMapper.readValue<FeedAd>(feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!.json)
 
-        val førEndringJson = objectMapper.readValue<FeedAd>(hentetAdFørEndring.json)
-        val etterEndringJson = objectMapper.readValue<FeedAd>(hentetAdEtterEndring.json)
-
-        assertEquals(emptyList(), førEndringJson.contactList)
-        assertEquals(emptyList(), etterEndringJson.contactList)
-        assertNull(hentetAdFørEndring.kilde)
-        assertNotNull(hentetAdEtterEndring.kilde)
-        assertEquals("Stillingsregistrering", hentetAdEtterEndring.kilde)
-        assertThat(hentetAdFørEndring).usingRecursiveComparison().ignoringFields("kilde").isEqualTo(hentetAdEtterEndring)
-        assertThat(førEndringJson).usingRecursiveComparison().isEqualTo(etterEndringJson)
+        assertNull(hentetAdFørEndring.employer.orgnr)
+        assertEquals("922422249", hentetAdEtterEndring.employer.orgnr)
+        assertThat(hentetAdFørEndring).usingRecursiveComparison().ignoringFields("employer.orgnr").isEqualTo(hentetAdEtterEndring)
     }
+
+    @Test
+    fun `OppdaterDetaljer holder annonse skjult når privacy ikke er SHOW_ALL`() {
+        val ad = objectMapper.readValue(javaClass.getResourceAsStream("/ad_dto.json"), AdDTO::class.java)
+            .copy(uuid = UUID.randomUUID().toString())
+        feedService.lagreNyStillingsAnnonse(ad)
+
+        feedService.lagreOppdaterteDetaljer(listOf(ad.copy(privacy = "INTERNAL_NOT_SHOWN")))
+        val hentetEtterEndring = feedRepository.hentFeedItem(UUID.fromString(ad.uuid), false)!!
+
+        assertEquals("", hentetEtterEndring.json)
+    }
+
 }


### PR DESCRIPTION
## Hva

Stillinger som ble endret i StillingsAdmin (f.eks. av NKS) fikk ikke oppdatert innhold i feeden — bl.a. sto `orgnr` igjen som `null` selv etter at det var satt.

## Årsak

`KafkaStillingDetaljerListener` kalte kun `lagreKilde(...)` (midlertidig migreringskode), og hoppet over `lagreOppdaterteDetaljer(...)`. Dermed ble aldri `feed_item.json` oppdatert ved endringer.

## Endring

- Detalj-listener kaller nå `lagreOppdaterteDetaljer(...)`
- Fjernet midlertidig migreringskode (`lagreKilde` / `oppdaterKildeForFeedItem`)
- Rettet `active`-betingelse i `lagreOppdaterteDetaljer` til å matche `lagreNyStillingsAnnonse` (`status=ACTIVE && source!=DIR && privacy=SHOW_ALL`)
- Tester for orgnr-oppdatering og privacy-maskering
