### PR TITLE
Fjern Kotlin-kompilatoradvarsler i main- og testkode

### DIFF
--- a/src/main/kotlin/no/nav/pam/stilling/feed/DenylistRefreshTask.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/DenylistRefreshTask.kt
@@ -13,7 +13,7 @@ class DenylistRefreshTask(
 
     override fun run() {
         val nyDenylist = tokenRepository.hentInvaliderteTokens()
-        LOG.info("Refresher denylist - Antall invaliderte tokens: ${nyDenylist?.size}")
+        LOG.info("Refresher denylist - Antall invaliderte tokens: ${nyDenylist.size}")
         securityConfig.updateDenylist(nyDenylist)
     }
 }

--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedRepository.kt
@@ -45,7 +45,7 @@ class FeedRepository(private val txTemplate: TxTemplate) {
                     this.setString(1, oppdatertJson)
                     this.setObject(2, id)
                 }.executeUpdate()
-        } ?: 0
+        }
 
     fun hentFeedItem(id: UUID, skalIgnorereFinn: Boolean): FeedItem? {
         return txTemplate.doInTransactionNullable { ctx ->

--- a/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/FeedService.kt
@@ -124,7 +124,7 @@ class FeedService(
                 lagreNyStillingsAnnonse(ad)
             }.filterNotNull().toList()
             return@doInTransaction items
-        }!!
+        }
     }
 
     fun hentStillingsAnnonse(uuid: UUID): FeedItem? {

--- a/src/main/kotlin/no/nav/pam/stilling/feed/LeaderElector.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/LeaderElector.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.slf4j.LoggerFactory
 import java.net.InetAddress
-import java.net.URL
+import java.net.URI
 import java.time.LocalDateTime
 
 class LeaderElector(private val electorPath: String) {
@@ -42,7 +42,7 @@ class LeaderElector(private val electorPath: String) {
         if (electorPath == "NOLEADERELECTION")
             return hostname
         if (leader.isBlank() || lastCalled.isBefore(LocalDateTime.now().minusMinutes(2))) {
-            leader = mapper.readValue(URL(electorUri).readText(), Elector::class.java).name
+            leader = mapper.readValue(URI.create(electorUri).toURL().readText(), Elector::class.java).name
             lastCalled = LocalDateTime.now()
         }
         return leader

--- a/src/main/kotlin/no/nav/pam/stilling/feed/OpenApi.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/OpenApi.kt
@@ -54,17 +54,18 @@ fun getOpenApiPlugin() = OpenApiPlugin { openApiConfig ->
 }
 
 private fun setResponseHeadersDocumentation(content: ObjectNode) {
-    content["paths"].fields().forEachRemaining {
-        if (!listOf("/api/v1/feed", "/api/v1/feed/<feedPageId>").contains(it.key)) return@forEachRemaining
+    val pathsNode = content["paths"] as? ObjectNode ?: return
+    pathsNode.properties().forEach { (path, pathNode) ->
+        if (!listOf("/api/v1/feed", "/api/v1/feed/<feedPageId>").contains(path)) return@forEach
 
         try {
-            val okResponseNode = it.value["get"]["responses"]["200"] as ObjectNode
+            val okResponseNode = pathNode["get"]["responses"]["200"] as ObjectNode
             okResponseNode.putObject("headers").let { headersNode ->
                 headersNode.putObject("ETag").put("description", "Entity tag providing a ID for the resource version.").put("type", "UUID")
                 headersNode.putObject("Last-Modified").put("description", "Last modified datetime of resource.").put("type", "RFC 1123 formatted datetime")
             }
         } catch (e: Exception) {
-            return@forEachRemaining
+            return@forEach
         }
     }
 }

--- a/src/main/kotlin/no/nav/pam/stilling/feed/TokenController.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/TokenController.kt
@@ -44,7 +44,7 @@ class TokenController(private val securityConfig: SecurityConfig, private val to
         val konsument = objectMapper.readValue<KonsumentDTO>(ctx.body())
         val success = tokenService.lagreKonsument(konsument)
 
-        if (success != null && success > 0) {
+        if (success > 0) {
             LOG.info("New consumer created with ID ${konsument.id}")
             ctx.status(200)
             ctx.json(konsument)
@@ -116,8 +116,8 @@ class TokenController(private val securityConfig: SecurityConfig, private val to
     }
 
     private fun hentKonsumenter(ctx: Context) = try {
-        val spørring = ctx.queryParam("q")
-        if (spørring !== null) {
+        val spørring = ctx.queryParamMap()["q"]?.firstOrNull()
+        if (spørring != null) {
             val konsumenter = tokenService.hentKonsumenter(spørring)
             ctx.json(konsumenter)
         } else {

--- a/src/main/kotlin/no/nav/pam/stilling/feed/TokenRepository.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/TokenRepository.kt
@@ -38,7 +38,7 @@ class TokenRepository(private val txTemplate: TxTemplate) {
                 konsumenter.add(KonsumentDTO.fraDatabase(rs))
 
              return@doInTransaction konsumenter
-        } ?: emptyList()
+        }
 
     fun hentKonsument(id: UUID) =
         txTemplate.doInTransaction { ctx ->

--- a/src/main/kotlin/no/nav/pam/stilling/feed/TokenService.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/TokenService.kt
@@ -28,7 +28,7 @@ class TokenService(private val tokenRepository: TokenRepository,
             } else {
                 return@doInTransaction eksisterende.first()
             }
-        } ?: throw IllegalArgumentException("Greide hverken å hente eller opprette konsument ${konsument.id}")
+        }
 
     fun finnKonsument(konsumentId: UUID) = tokenRepository.hentKonsument(konsumentId)
 
@@ -43,7 +43,7 @@ class TokenService(private val tokenRepository: TokenRepository,
     fun hentPublicToken() =
         txTemplate.doInTransactionNullable { ctx ->
             tokenRepository.hentKonsument(SecurityConfig.PUBLIC_TOKEN_ID).firstOrNull()?.let { k ->
-                tokenRepository.hentGyldigeTokens(k.id)?.firstOrNull()
+                tokenRepository.hentGyldigeTokens(k.id).firstOrNull()
             }
         }
 
@@ -95,5 +95,4 @@ class TokenService(private val tokenRepository: TokenRepository,
             return@doInTransaction jwtToken
         }
 }
-
 

--- a/src/main/kotlin/no/nav/pam/stilling/feed/dto/FeedAd.kt
+++ b/src/main/kotlin/no/nav/pam/stilling/feed/dto/FeedAd.kt
@@ -155,7 +155,6 @@ private fun mapCategories(ad: AdDTO): List<FeedCategory> {
 
     val cats = ad.categoryList
         .asSequence()
-        .filter { c -> c.categoryType != null && c.code != null }
         .mapNotNull { c ->
             FeedCategory(
                 categoryType = c.categoryType,
@@ -206,14 +205,14 @@ data class Feed(
     val home_page_url: String = "https://arbeidsplassen.nav.no",
     val feed_url: String = "https://arbeidsplassen.nav.no/stillinger-feed",
     val description: String = "Feed med stillinger fra arbeidsplassen.no - En av Norges største oversikter over utlyste stillinger",
-    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @field:JsonInclude(JsonInclude.Include.ALWAYS)
     val next_url: String?,
     @JsonIgnore
     val lastModified: ZonedDateTime = ZonedDateTime.now(),
     @JsonIgnore
     val etag: String = "",
     val id: UUID = UUID.randomUUID(),
-    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @field:JsonInclude(JsonInclude.Include.ALWAYS)
     val next_id: UUID? = null,
     val items: MutableList<FeedLine> = mutableListOf()
 ) {
@@ -235,7 +234,7 @@ data class FeedLine(
     val title: String,
     val content_text: String = "Stillingsannonse",
     val date_modified: ZonedDateTime?, // kanskje ikke lurt å ha med dette?
-    @JsonProperty("_feed_entry")
+    @field:JsonProperty("_feed_entry")
     val feed_entry: FeedEntry
 ) {
     companion object {
@@ -270,7 +269,7 @@ data class FeedEntry(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class FeedEntryContent(
     val uuid: UUID,
-    @JsonProperty("ad_content")
+    @field:JsonProperty("ad_content")
     val json: FeedAd?,
     val sistEndret: ZonedDateTime,
     val status: String

--- a/src/test/kotlin/no/nav/pam/stilling/feed/KafkaListenerTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/KafkaListenerTest.kt
@@ -71,7 +71,7 @@ class KafkaListenerTest {
         Assertions.assertThat(adIds.size).isEqualTo(Feed.defaultPageSize * 3 + 1)
 
         admin.describeTopics(listOf(topic)).allTopicNames().get().forEach { println(it) }
-        admin.listConsumerGroups().all().get().forEach { println(it) }
+        admin.listGroups().all().get().forEach { println(it) }
 
         var maxAntallForsøk = 2
         var ad: FeedItem? = null
@@ -84,4 +84,3 @@ class KafkaListenerTest {
         Assertions.assertThat(ad).isNotNull
     }
 }
-

--- a/src/test/kotlin/no/nav/pam/stilling/feed/LocalApplication.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/LocalApplication.kt
@@ -13,8 +13,8 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.pam.stilling.feed.config.TxTemplate
 import no.nav.pam.stilling.feed.dto.KonsumentDTO
 import no.nav.pam.stilling.feed.sikkerhet.SecurityConfig
-import org.testcontainers.containers.KafkaContainer
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 import java.util.*
 
@@ -24,15 +24,15 @@ fun main() {
 
 const val lokalUrlBase = "http://localhost:8080"
 
-val lokalPostgres: PostgreSQLContainer<*> =
+val lokalPostgres: PostgreSQLContainer =
     PostgreSQLContainer(DockerImageName.parse("postgres:14.4-alpine"))
         .withDatabaseName("dbname")
         .withUsername("username")
         .withPassword("pwd")
         .apply { start() }
 
-val lokalKafka: KafkaContainer =
-    KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.2")).withKraft().apply { start() }
+val lokalKafka: ConfluentKafkaContainer =
+    ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.2")).apply { start() }
 
 val dataSource = HikariConfig().apply {
     jdbcUrl = lokalPostgres.jdbcUrl

--- a/src/test/kotlin/no/nav/pam/stilling/feed/TxTemplateTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/TxTemplateTest.kt
@@ -77,5 +77,5 @@ class TxTemplateTest {
             ctx.connection()
                 .prepareStatement("SELECT * FROM feed_consumer").executeQuery()
                 .use { generateSequence { if (it.next()) KonsumentDTO.fraDatabase(it) else null }.toList() }
-        } ?: emptyList()
+        }
 }

--- a/src/test/kotlin/no/nav/pam/stilling/feed/servicetest/FeedServiceTest.kt
+++ b/src/test/kotlin/no/nav/pam/stilling/feed/servicetest/FeedServiceTest.kt
@@ -118,7 +118,7 @@ class FeedServiceTest {
         var side = feedService.hentFeedHvis(førsteSide!!.id)!!
         side.items.forEach { adIds.remove(it.feed_entry.uuid) }
         while (side.next_id != null) {
-            side = feedService.hentFeedHvis(side.next_id!!)!!
+            side = feedService.hentFeedHvis(side.next_id)!!
             side.items.forEach { adIds.remove(it.feed_entry.uuid) }
         }
         Assertions.assertThat(adIds).isEmpty()


### PR DESCRIPTION
Kompileringen ga en rekke advarsler fra Kotlin og deprecated Java-API-er.

- Fjernet unødvendige null-sjekker, `?:`-fallbacks og `!!` der typer allerede er ikke-null.
- Byttet deprecated API-bruk:
  - `URL(String)` -> `URI.create(...).toURL()` i `LeaderElector`.
  - Deprecated Jackson-iterasjon i `OpenApi` er erstattet med `properties()`.
  - Deprecated Testcontainers-klasser i tester er byttet til nye pakker (`org.testcontainers.kafka.*` og `org.testcontainers.postgresql.*`).
  - Kafka admin-kall i test er oppdatert fra `listConsumerGroups()` til `listGroups()`.
- Lagt til eksplisitte `@field:` targets for relevante Jackson-annotasjoner i `FeedAd` for å unngå framtidige Kotlin-advarsler.