### PR TITLE
Bytt til JDK_JAVA_OPTIONS i Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 EXPOSE 8080
 
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
-ENV JAVA_TOOL_OPTIONS="--enable-preview -XX:-OmitStackTraceInFastThrow -XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+ENV JDK_JAVA_OPTIONS="--enable-preview -XX:-OmitStackTraceInFastThrow -XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
 
 COPY build/install/*/lib /lib
 CMD ["-cp", "/lib/*", "no.nav.pam.stilling.feed.ApplicationKt"]


### PR DESCRIPTION
Bytter fra JAVA_TOOL_OPTIONS til JDK_JAVA_OPTIONS i Dockerfile.
NAIS auto-instrumentering injiserer JAVA_TOOL_OPTIONS med -javaagent, som kan overstyre JVM-flaggene våre. Dette fjerner konflikten når auto-instrumentering er aktivert.